### PR TITLE
Add POD encoding parameter to silence warnings in pod2text, metacpan

### DIFF
--- a/lib/Debian/Dpkg/Version.pm
+++ b/lib/Debian/Dpkg/Version.pm
@@ -46,6 +46,8 @@ use overload
     'bool' => sub { return $_[0]->is_valid(); },
     'fallback' => 1;
 
+=encoding utf-8
+
 =head1 NAME
 
 Debian::Dpkg::Version - handling and comparing dpkg-style version numbers


### PR DESCRIPTION
With pod2text I'm getting the following error:

<pre>
lib/Debian/Dpkg/Version.pm around line 388: Non-ASCII character seen before =encoding in 'Rapha�l'. Assuming UTF-8
    Don Armstrong <don@donarmstrong.com>, Colin Watson <cjwatson@debian.org>
    and Raphaël Hertzog <hertzog@debian.org>, based on the implementation in
    "dpkg/lib/vercmp.c" by Ian Jackson and others.

POD document had syntax errors at /usr/bin/pod2text line 81.
</pre>

Also you can see this at the bottom of the page on metacpan:

https://metacpan.org/pod/Debian::Dpkg::Version